### PR TITLE
Explicitly set text color to white

### DIFF
--- a/app/_components/Experience/Dashboard.tsx
+++ b/app/_components/Experience/Dashboard.tsx
@@ -15,7 +15,8 @@ const NavItem = ({ label, handleClick, isActive }: NavItemProps) => {
   return (
     <button
       className={
-        "border-b-2 border-b-transparent" + ` ${isActive ? activeStyles : ""}`
+        "border-b-2 border-b-transparent text-white" +
+        ` ${isActive ? activeStyles : ""}`
       }
       onClick={handleClick}
     >


### PR DESCRIPTION
Text color is currently not set, which means it's black for non-dark-mode browsers. This makes it look like there is no text, against the black terminal.