### PR TITLE
Adjust ring-light speed and never go to negative values

### DIFF
--- a/app/_components/Experience/Light.tsx
+++ b/app/_components/Experience/Light.tsx
@@ -3,7 +3,6 @@ import * as THREE from "three";
 import { extend, ReactThreeFiber, useThree } from "@react-three/fiber";
 import { shaderMaterial } from "@react-three/drei";
 
-type ShaderParams = any;
 export const ColorShiftMaterial = shaderMaterial(
   { time: 0, color: new THREE.Color(0.2, 0.0, 0.1), speed: 5.0 },
   // vertex shader
@@ -21,39 +20,8 @@ export const ColorShiftMaterial = shaderMaterial(
     uniform vec3 color;
     varying vec2 vUv;
     void main() {
-      gl_FragColor.rgba = vec4(vec3(sin(time * speed) + 0.8), 1.0);
+      gl_FragColor.rgba = vec4(vec3(abs(sin(time * speed)) + 0.1), 1.0);
     }
   `
 );
-
-declare global {
-  namespace JSX {
-    interface IntrinsicElements {
-      colorShiftMaterial: typeof shaderMaterial & ShaderParams;
-    }
-  }
-}
 extend({ ColorShiftMaterial });
-
-type Props = {
-  renderOrder: number;
-  position?: [number, number, number];
-};
-export const Light = ({ renderOrder, position = [0, 0, 0] }: Props) => {
-  const { clock } = useThree();
-  const speed = useMemo(() => Math.random() * (6.0 - 4.0) + 4.0, []);
-  console.log(speed);
-  return (
-    <mesh position={position}>
-      <sphereGeometry />
-      <colorShiftMaterial
-        emissive={[1, 1, 1]}
-        emissiveIntensity={10}
-        color="green"
-        transparent
-        time={clock.elapsedTime}
-        speed={speed}
-      />
-    </mesh>
-  );
-};

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -67,7 +67,7 @@ export function Model(props) {
             emissiveIntensity={30}
             color="green"
             time={clock.elapsedTime}
-            speed={1.0}
+            speed={0.6}
             depthWrite={false}
             depthTest={false}
           />


### PR DESCRIPTION
- Slows down ring light strobe speed
- Uses abs() on sin() value to never cross into negative values. This ensures that the light doesn't go completely black, which is quite jarring to the eyes 