### PR TITLE
Adjust mobile console

### DIFF
--- a/app/_components/Experience/Spaceship.tsx
+++ b/app/_components/Experience/Spaceship.tsx
@@ -15,11 +15,6 @@ export const Spaceship = () => {
   const spaceshipRef = useRef<Group>(null);
   const { direction } = useFlightContext();
 
-  const scalingFactor =
-    window.innerWidth < mobileBreakPoint
-      ? spaceshipMobileScalingFactor
-      : { x: 1, y: 1, z: 1 };
-
   useFrame((_, delta) => {
     if (spaceshipRef.current && direction) {
       if (direction.x === 0 && direction.y === 0) {
@@ -36,11 +31,7 @@ export const Spaceship = () => {
 
   const [x, y, z] = initialCameraPosition;
   return (
-    <group
-      position={[x, y - 0.2, z - 4]}
-      scale={[scalingFactor.x, scalingFactor.y, scalingFactor.z]}
-      ref={spaceshipRef}
-    >
+    <group position={[x, y - 0.2, z - 4]} ref={spaceshipRef}>
       <Dashboard />
       <Model />
     </group>

--- a/app/_components/Experience/Spaceship.tsx
+++ b/app/_components/Experience/Spaceship.tsx
@@ -1,9 +1,6 @@
 import { useRef } from "react";
 import { useFrame } from "@react-three/fiber";
-import {
-  spaceshipMobileScalingFactor,
-  mobileBreakPoint,
-} from "@sharedData/index";
+import { mobileBreakPoint } from "@sharedData/index";
 import { Group } from "three";
 import { initialCameraPosition } from "@sharedData/index";
 import { dampE } from "@functions/damp";

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -59,6 +59,8 @@ export function Model(props) {
     shipPanels,
   } = useGLTF("/baked/spaceship.glb").nodes;
 
+  const isMobile = width <= mobileBreakPoint;
+
   return (
     <group {...props} dispose={null}>
       <mesh
@@ -79,7 +81,10 @@ export function Model(props) {
       </mesh>
 
       {/* Console */}
-      <group position={[0, 0.4, 0]}>
+      <group
+        position={isMobile ? [0, 1.4, 0] : [0, 0.4, 0]}
+        scale={isMobile ? [1.8, 1.5, 1.5] : 1}
+      >
         {/* Console Center */}
         <mesh
           geometry={consoleBack.geometry}
@@ -118,7 +123,7 @@ export function Model(props) {
         </mesh>
 
         {/* Console Sides */}
-        {width > mobileBreakPoint ? (
+        {!isMobile ? (
           <>
             <mesh
               geometry={consoleBackSides.geometry}

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -7,7 +7,10 @@ import { useGLTF, useTexture } from "@react-three/drei";
 import { ColorShiftMaterial } from "./Light";
 import { useThree } from "@react-three/fiber";
 import { MeshPhysicalMaterial } from "three";
-import { mobileBreakPoint } from "@sharedData/index.ts";
+import {
+  spaceshipMobileScalingFactor,
+  mobileBreakPoint,
+} from "@sharedData/index.ts";
 import { useWindowDimensions } from "@hooks/useWindowDimensions";
 
 const glassMaterial = new MeshPhysicalMaterial({
@@ -60,25 +63,29 @@ export function Model(props) {
   } = useGLTF("/baked/spaceship.glb").nodes;
 
   const isMobile = width <= mobileBreakPoint;
+  const shipScalingFactor = isMobile ? spaceshipMobileScalingFactor : 1;
 
   return (
     <group {...props} dispose={null}>
-      <mesh
-        geometry={glass.geometry}
-        material={glassMaterial}
-        renderOrder={renderOrders.glass}
-      ></mesh>
+      {/* Ship & Glass */}
+      <group scale={shipScalingFactor}>
+        <mesh
+          geometry={glass.geometry}
+          material={glassMaterial}
+          renderOrder={renderOrders.glass}
+        ></mesh>
 
-      {/* Ship */}
-      <mesh geometry={ship.geometry} renderOrder={renderOrders.ship}>
-        <meshBasicMaterial map={shipTexture} depthTest={false} />
-      </mesh>
-      <mesh
-        geometry={shipPanels.geometry}
-        renderOrder={renderOrders.shipPanels}
-      >
-        <meshBasicMaterial map={shipTexture} depthTest={false} />
-      </mesh>
+        {/* Ship */}
+        <mesh geometry={ship.geometry} renderOrder={renderOrders.ship}>
+          <meshBasicMaterial map={shipTexture} depthTest={false} />
+        </mesh>
+        <mesh
+          geometry={shipPanels.geometry}
+          renderOrder={renderOrders.shipPanels}
+        >
+          <meshBasicMaterial map={shipTexture} depthTest={false} />
+        </mesh>
+      </group>
 
       {/* Console */}
       <group

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -7,10 +7,7 @@ import { useGLTF, useTexture } from "@react-three/drei";
 import { ColorShiftMaterial } from "./Light";
 import { useThree } from "@react-three/fiber";
 import { MeshPhysicalMaterial } from "three";
-import {
-  spaceshipMobileScalingFactor,
-  mobileBreakPoint,
-} from "@sharedData/index.ts";
+import { mobileBreakPoint } from "@sharedData/index.ts";
 import { useWindowDimensions } from "@hooks/useWindowDimensions";
 
 const glassMaterial = new MeshPhysicalMaterial({
@@ -63,7 +60,7 @@ export function Model(props) {
   } = useGLTF("/baked/spaceship.glb").nodes;
 
   const isMobile = width <= mobileBreakPoint;
-  const shipScalingFactor = isMobile ? spaceshipMobileScalingFactor : 1;
+  const shipScalingFactor = isMobile ? [0.5, 0.9, 1] : 1;
 
   return (
     <group {...props} dispose={null}>

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -38,6 +38,11 @@ export function Model(props) {
   shipTexture.flipY = false;
   const consoleTexture = useTexture("/baked/baked-console-4096.jpg");
   consoleTexture.flipY = false;
+  // Note: Splitting the model like this is necessary in order to work around
+  //       the limitations of ejecting from depthTest. Certain parts of the model
+  //       must be explicitly rendered on top of others.
+  // Note: Splitting the console into center/side parts is necessary for removing
+  //       the sides on mobile
   const {
     console,
     consoleBack,

--- a/app/_components/Experience/SpaceshipModel.jsx
+++ b/app/_components/Experience/SpaceshipModel.jsx
@@ -61,6 +61,8 @@ export function Model(props) {
 
   const isMobile = width <= mobileBreakPoint;
   const shipScalingFactor = isMobile ? [0.5, 0.9, 1] : 1;
+  const consoleScalingFactor = isMobile ? [0.9, 1.2, 1.2] : 1;
+  const consolePosition = isMobile ? [0, 0.9, 0] : [0, 0.4, 0];
 
   return (
     <group {...props} dispose={null}>
@@ -86,8 +88,8 @@ export function Model(props) {
 
       {/* Console */}
       <group
-        position={isMobile ? [0, 1.4, 0] : [0, 0.4, 0]}
-        scale={isMobile ? [1.8, 1.5, 1.5] : 1}
+        position={consolePosition}
+        scale={isMobile ? consoleScalingFactor : 1}
       >
         {/* Console Center */}
         <mesh

--- a/app/_utilities/sharedData/index.ts
+++ b/app/_utilities/sharedData/index.ts
@@ -1,4 +1,4 @@
-export const spaceshipMobileScalingFactor = { x: 0.5, y: 0.9, z: 1 };
+export const spaceshipMobileScalingFactor = [0.5, 0.9, 1];
 
 export const mobileBreakPoint = 640;
 

--- a/app/_utilities/sharedData/index.ts
+++ b/app/_utilities/sharedData/index.ts
@@ -1,5 +1,3 @@
-export const spaceshipMobileScalingFactor = [0.5, 0.9, 1];
-
 export const mobileBreakPoint = 640;
 
 export const initialCameraPosition = [0, 0, 20] as const;


### PR DESCRIPTION
Adjusts the scale and position of the console on mobile.

- Places the scaling factor for the ship on the ship and glass parts only (not the console)
- scaling factor for the ship is no longer exported
- Console now has its own scaling factor for mobile

Console is now larger on mobile, which will allow more room for the <Dashboard>