### PR TITLE
Dialogue transition delay

### DIFF
--- a/app/_components/Dialogue.tsx
+++ b/app/_components/Dialogue.tsx
@@ -5,6 +5,7 @@ import { mobileBreakPoint } from "@sharedData/index";
 import { useWindowDimensions } from "@/app/_utilities/hooks/useWindowDimensions";
 import { useDialogueContext } from "@contexts/dialogueContext";
 import { usePageContext } from "@contexts/pageContext";
+import { pageTransitionAnimationDelay } from "@sharedData/index";
 import styles from "./dialogue.module.css";
 
 import { Space_Mono } from "next/font/google";
@@ -41,7 +42,7 @@ export const Dialogue = () => {
         setTimeout(() => {
           setIsOpen(true);
           setCurrentTimeout(null);
-        }, 2000)
+        }, pageTransitionAnimationDelay)
       );
     }
   }, [page, previousPage, currentTimeout]);

--- a/app/_components/Dialogue.tsx
+++ b/app/_components/Dialogue.tsx
@@ -17,13 +17,6 @@ export const Dialogue = () => {
   const { width } = useWindowDimensions();
   const isMobile = width <= mobileBreakPoint;
   const { dialogue, incrementDialogue } = useDialogueContext();
-  const [hasRendered, setHasRendered] = useState(false);
-
-  useEffect(() => {
-    if (!hasRendered) {
-      setHasRendered(true);
-    }
-  }, [hasRendered, setHasRendered]);
 
   if (!dialogue) {
     return null;

--- a/app/_components/Dialogue.tsx
+++ b/app/_components/Dialogue.tsx
@@ -4,6 +4,7 @@ import classnames from "classnames";
 import { mobileBreakPoint } from "@sharedData/index";
 import { useWindowDimensions } from "@/app/_utilities/hooks/useWindowDimensions";
 import { useDialogueContext } from "@contexts/dialogueContext";
+import { usePageContext } from "@contexts/pageContext";
 import styles from "./dialogue.module.css";
 
 import { Space_Mono } from "next/font/google";
@@ -14,9 +15,36 @@ const spaceMono = Space_Mono({
 });
 
 export const Dialogue = () => {
+  const { page } = usePageContext();
   const { width } = useWindowDimensions();
-  const isMobile = width <= mobileBreakPoint;
   const { dialogue, incrementDialogue } = useDialogueContext();
+  const [isOpen, setIsOpen] = useState<boolean>(true);
+  const [currentTimeout, setCurrentTimeout] = useState<NodeJS.Timeout | null>(
+    null
+  );
+  const [previousPage, setPreviousPage] = useState<string>(page || "/");
+  const isMobile = width <= mobileBreakPoint;
+
+  // Adds a delay to the visual re-opening of the dialogue
+  // on page change.
+  // Does not interfere with how the dialogue object is changed
+  useEffect(() => {
+    if (page !== previousPage) {
+      page && setPreviousPage(page);
+      setIsOpen(false);
+
+      // Clear the previous timeout if it exists
+      if (currentTimeout) {
+        clearTimeout(currentTimeout);
+      }
+      setCurrentTimeout(
+        setTimeout(() => {
+          setIsOpen(true);
+          setCurrentTimeout(null);
+        }, 2000)
+      );
+    }
+  }, [page, previousPage, currentTimeout]);
 
   if (!dialogue) {
     return null;
@@ -30,7 +58,7 @@ export const Dialogue = () => {
         styles.container,
         "bg-blue-800 border-white border-2 p-4 rounded w-[60vw] z-10 block absolute top-8 left-1/2 transition-all duration-200 bg-gradient-to-b from-[#000b75] to-[#000640]",
         {
-          [styles.containerClosed]: !text,
+          [styles.containerClosed]: !text || !isOpen,
           "w-[60vw]": !isMobile,
           "w-[90vw]": isMobile,
         }
@@ -44,7 +72,11 @@ export const Dialogue = () => {
           "text-white empty:before:content-[''] empty:before:inline-block cursor-default"
         )}
       >
-        {text}
+        {/*
+         dialogue.text will change before dialogue closes 
+         this check will immediately clear the text while closing
+        */}
+        {isOpen ? text : null}
       </p>
       <div
         className={classnames(styles.triangle, "absolute bottom-1 right-1")}

--- a/app/_components/Dialogue.tsx
+++ b/app/_components/Dialogue.tsx
@@ -16,8 +16,7 @@ const spaceMono = Space_Mono({
 export const Dialogue = () => {
   const { width } = useWindowDimensions();
   const isMobile = width <= mobileBreakPoint;
-  const { dialogue, incrementDialogue, dialogueSet, setDialogueSet } =
-    useDialogueContext();
+  const { dialogue, incrementDialogue } = useDialogueContext();
   const [hasRendered, setHasRendered] = useState(false);
 
   useEffect(() => {

--- a/app/_components/Experience/Hologram.tsx
+++ b/app/_components/Experience/Hologram.tsx
@@ -27,7 +27,7 @@ export const Hologram = ({
   const { page } = usePageContext();
   // This state is used to check if the value of 'page' has changed
   const [previousPage, setPreviousPage] = useState<string>(page || "/");
-  const [isOpening, setIsOpening] = useState<boolean>(true);
+  const [isOpen, setIsOpen] = useState<boolean>(true);
   const [currentTimeout, setCurrentTimeout] = useState<NodeJS.Timeout | null>(
     null
   );
@@ -57,7 +57,7 @@ export const Hologram = ({
     return null;
   });
 
-  const hologramScale: Scale = isOpening ? [0.04, 0.04, 0.04] : [0, 0.04, 0];
+  const hologramScale: Scale = isOpen ? [0.04, 0.04, 0.04] : [0, 0.04, 0];
 
   useFrame((_, delta) => {
     if (ref.current) {
@@ -71,7 +71,7 @@ export const Hologram = ({
     // Only run on page change
     if (page !== previousPage) {
       page && setPreviousPage(page);
-      setIsOpening(false);
+      setIsOpen(false);
 
       // Clear the previous timeout if it exists
       if (currentTimeout) {
@@ -82,12 +82,12 @@ export const Hologram = ({
           if (page && pageNames.includes(page)) {
             setGeometry(geometryMap[page]);
           }
-          setIsOpening(true);
+          setIsOpen(true);
           setCurrentTimeout(null);
         }, 2000)
       );
     }
-  }, [page, previousPage, isOpening, currentTimeout, geometryMap]);
+  }, [page, previousPage, isOpen, currentTimeout, geometryMap]);
 
   if (!geometry) return null;
 

--- a/app/_components/Experience/Hologram.tsx
+++ b/app/_components/Experience/Hologram.tsx
@@ -7,6 +7,7 @@ import { pageNames } from "@customTypes/pageNames";
 import { damp3 } from "maath/easing";
 
 import { holographicMaterial } from "@/app/_materials/holographicMaterial";
+import { pageTransitionAnimationDelay } from "@sharedData/index";
 
 type Scale = [x: number, y: number, z: number];
 
@@ -84,7 +85,7 @@ export const Hologram = ({
           }
           setIsOpen(true);
           setCurrentTimeout(null);
-        }, 2000)
+        }, pageTransitionAnimationDelay)
       );
     }
   }, [page, previousPage, isOpen, currentTimeout, geometryMap]);

--- a/app/_utilities/sharedData/index.ts
+++ b/app/_utilities/sharedData/index.ts
@@ -1,3 +1,5 @@
 export const mobileBreakPoint = 640;
 
 export const initialCameraPosition = [0, 0, 20] as const;
+
+export const pageTransitionAnimationDelay = 2000;


### PR DESCRIPTION
Adds a delay to the reopening of the dialogue box, allowing the user to focus on the `<Coalescent />` transitions. Also makes it look like the first message of each `dialogueSet` is in response to the fully-formed `<Coalescent />` model.

Before:
When changing `dialogueSet`, the `dialogueSet.text` changes appear instantly.

Now:
When changing `dialogueSet`, the text in the `<Dialogue />` component will disappear immediately as it closes, and the same delay applied to `<Hologram />` changes will occur before re-opening the `<Dialogue />` with the new text.