### PR TITLE
Display DPR

### DIFF
--- a/app/_components/DevicePixelRatio.tsx
+++ b/app/_components/DevicePixelRatio.tsx
@@ -1,0 +1,10 @@
+"use client";
+import { useEffect, useState } from "react";
+
+export const DevicePixelRatio = () => {
+  const [text, setText] = useState<string>("");
+  useEffect(() => {
+    setText(window?.devicePixelRatio.toString());
+  }, []);
+  return <p className="absolute top-4 left-4 z-30">DPR: {text}</p>;
+};

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,6 +9,7 @@ import { RouteChangeListener } from "@components/RouteChangeListener";
 import { Dialogue } from "@components/Dialogue";
 import { IncomingData } from "@components/IncomingData";
 import { Experience } from "@components/Experience";
+import { DevicePixelRatio } from "./_components/DevicePixelRatio";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -36,6 +37,7 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
+        <DevicePixelRatio /> {/* Delete after testing */}
         <WithProviders>
           {/*  page-specific content can be re-added here
           <div className="flex absolute z-10 justify-center items-center w-full h-full">


### PR DESCRIPTION
This PR displays the Device Pixel Ratio on the screen. This is for the purpose of figuring out if the positioning variations of the Dashboard on different devices is due to a difference in DPR.

This change should be removed after testing.