### PR TITLE
Adjust position for highDPR devices

### DIFF
--- a/app/_components/Experience/Dashboard.tsx
+++ b/app/_components/Experience/Dashboard.tsx
@@ -28,6 +28,10 @@ const NavItem = ({ label, handleClick, isActive }: NavItemProps) => {
   );
 };
 
+const positions = {
+  lowDPR: [0, -2.29, -0.86] as const,
+  highDPR: [0, -1.91, -0.86] as const,
+};
 export const Dashboard = () => {
   const router = useRouter();
   const { page, setPage } = usePageContext();
@@ -40,7 +44,9 @@ export const Dashboard = () => {
   return (
     <Html
       transform
-      position={[0, -2.29, -0.86]}
+      position={
+        window?.devicePixelRatio >= 3 ? positions.highDPR : positions.lowDPR
+      }
       rotation={[-0.6, 0, 0]}
       as="div"
       className="flex w-72 justify-around"


### PR DESCRIPTION
The Dashboard was originally positioned too low on high-DPR devices. This change adjusts the position for devices with a DPR of 3 or higher