### PR TITLE
Interests mobile

### DIFF
--- a/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
+++ b/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
@@ -51,7 +51,7 @@ export const InterestsGroup = ({
       >
         <p
           // Text hidden on mobile
-          className={classnames("w-5/12 pr-2 text-sm hidden sm:block", {
+          className={classnames("w-4/12 pr-2 text-xs hidden sm:block", {
             "text-right pr-0 pl-2": isRTL,
           })}
         >
@@ -61,7 +61,7 @@ export const InterestsGroup = ({
         <div
           // Images full width on mobile
           className={classnames(
-            "flex sm:justify-end sm:w-7/12 w-full justify-start h-min",
+            "flex sm:justify-end sm:w-8/12 w-full justify-start h-min",
             {
               "flex-row-reverse": isRTL,
             }

--- a/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
+++ b/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
@@ -45,12 +45,13 @@ export const InterestsGroup = ({
         <Typist {...typistSettings}>{title}</Typist>
       </h2>
       <div
-        className={classnames("flex", {
+        className={classnames("flex ", {
           "flex-row-reverse": isRTL,
         })}
       >
         <p
-          className={classnames("w-5/12 pr-2 text-sm", {
+          // Text hidden on mobile
+          className={classnames("w-5/12 pr-2 text-sm hidden sm:block", {
             "text-right pr-0 pl-2": isRTL,
           })}
         >
@@ -58,9 +59,13 @@ export const InterestsGroup = ({
         </p>
 
         <div
-          className={classnames("flex justify-end w-7/12 h-min", {
-            "flex-row-reverse": isRTL,
-          })}
+          // Images full width on mobile
+          className={classnames(
+            "flex sm:justify-end sm:w-7/12 w-full justify-start h-min",
+            {
+              "flex-row-reverse": isRTL,
+            }
+          )}
         >
           {sightingsData.map((sightingProps, i) => (
             <Sighting {...sightingProps} isRTL={isRTL} key={i} />


### PR DESCRIPTION
Makes the Interests page responsive by:

- Removing the text
- Making the images take up the whole row

Also makes the text smaller on desktop, to feel less cluttered