### PR TITLE
Remove DPR related changes

### DIFF
--- a/app/_components/DevicePixelRatio.tsx
+++ b/app/_components/DevicePixelRatio.tsx
@@ -1,6 +1,10 @@
 "use client";
 import { useEffect, useState } from "react";
 
+// Issues have been found in the positioning of <Html> components
+// that have transform = true, and this may be related to different
+// device pixel ratios. Use this component to display DPR when testing
+// on different mobile devices.
 export const DevicePixelRatio = () => {
   const [text, setText] = useState<string>("");
   useEffect(() => {

--- a/app/_components/Experience/Dashboard.tsx
+++ b/app/_components/Experience/Dashboard.tsx
@@ -28,10 +28,6 @@ const NavItem = ({ label, handleClick, isActive }: NavItemProps) => {
   );
 };
 
-const positions = {
-  lowDPR: [0, -2.29, -0.86] as const,
-  highDPR: [0, -1.91, -0.86] as const,
-};
 export const Dashboard = () => {
   const router = useRouter();
   const { page, setPage } = usePageContext();
@@ -44,9 +40,7 @@ export const Dashboard = () => {
   return (
     <Html
       transform
-      position={
-        window?.devicePixelRatio >= 3 ? positions.highDPR : positions.lowDPR
-      }
+      position={[0, -2.29, -0.86]}
       rotation={[-0.6, 0, 0]}
       as="div"
       className="flex w-72 justify-around"

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -9,7 +9,6 @@ import { RouteChangeListener } from "@components/RouteChangeListener";
 import { Dialogue } from "@components/Dialogue";
 import { IncomingData } from "@components/IncomingData";
 import { Experience } from "@components/Experience";
-import { DevicePixelRatio } from "./_components/DevicePixelRatio";
 
 const inter = Inter({ subsets: ["latin"] });
 
@@ -37,7 +36,6 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body className={inter.className}>
-        <DevicePixelRatio /> {/* Delete after testing */}
         <WithProviders>
           {/*  page-specific content can be re-added here
           <div className="flex absolute z-10 justify-center items-center w-full h-full">


### PR DESCRIPTION
There is an issue on certain mobile devices where the Dashboard isn't displayed in the right position.
In order to test a theory that this may be due to a higher DPR, I added an element to display the DPR on the screen, to see if mobile devices with high DPRs consistently have the dashboard in the wrong place.

After testing, it seems that DPR is the cause, however a solution involving changing the position according to different DPRs seems non-viable. DPR 3 was found to require a negative y offset, and DPR 4 was found to require a positive y offset. I also found instances where the offset worked for some DPR 3 devices and not others. This seems to be a limitation of the `<Html/>` element, so I'm switching to a different approach.

I'm planning on rebuilding the `<Dashboard/>` with `<Text/>` elements instead for high dpr devices.