### PR TITLE
Carousel updates

### DIFF
--- a/app/_components/IncomingData/InterestsData/Carousel.tsx
+++ b/app/_components/IncomingData/InterestsData/Carousel.tsx
@@ -62,7 +62,6 @@ export const Carousel = () => {
             customTransition="all .5"
             transitionDuration={500}
             containerClass="carousel-container w-[95vw] "
-            removeArrowOnDeviceType={["tablet", "mobile"]}
             itemClass="carousel-item-padding-40-px"
           >
             {REORDERED_IMAGES.map(({ imageURL, alt }) => (

--- a/app/_components/IncomingData/InterestsData/Carousel.tsx
+++ b/app/_components/IncomingData/InterestsData/Carousel.tsx
@@ -56,14 +56,13 @@ export const Carousel = () => {
             responsive={responsive}
             swipeable={true}
             draggable={false}
-            showDots={true}
+            showDots={false}
             infinite={true}
             keyBoardControl={true}
             customTransition="all .5"
             transitionDuration={500}
             containerClass="carousel-container w-[80vw] "
             removeArrowOnDeviceType={["tablet", "mobile"]}
-            dotListClass="custom-dot-list-style"
             itemClass="carousel-item-padding-40-px"
           >
             {REORDERED_IMAGES.map(({ imageURL, alt }) => (

--- a/app/_components/IncomingData/InterestsData/Carousel.tsx
+++ b/app/_components/IncomingData/InterestsData/Carousel.tsx
@@ -48,7 +48,7 @@ export const Carousel = () => {
         <div className="fixed top-0 right-0 bottom-0 left-0 bg-black/80 z-[inherit] flex justify-center items-center">
           <button
             onClick={() => setCurrentImage(null)}
-            className="absolute top-6 right-8"
+            className="absolute top-6 right-8 z-50 bg-black/50 rounded"
           >
             <IoCloseSharp color="white" fontSize={30} />
           </button>

--- a/app/_components/IncomingData/InterestsData/Carousel.tsx
+++ b/app/_components/IncomingData/InterestsData/Carousel.tsx
@@ -73,6 +73,7 @@ export const Carousel = () => {
                 <Image
                   src={imageURL}
                   fill
+                  sizes="100vw"
                   style={{ objectFit: "contain" }}
                   alt={alt}
                 />

--- a/app/_components/IncomingData/InterestsData/Carousel.tsx
+++ b/app/_components/IncomingData/InterestsData/Carousel.tsx
@@ -61,22 +61,25 @@ export const Carousel = () => {
             keyBoardControl={true}
             customTransition="all .5"
             transitionDuration={500}
-            containerClass="carousel-container w-[80vw] "
+            containerClass="carousel-container w-[95vw] "
             removeArrowOnDeviceType={["tablet", "mobile"]}
             itemClass="carousel-item-padding-40-px"
           >
             {REORDERED_IMAGES.map(({ imageURL, alt }) => (
               <div
-                className="relative h-[80vh] w-full border-solid border-white"
+                className="relative h-[95vh] w-full flex justify-center"
                 key="imageURL"
               >
-                <Image
-                  src={imageURL}
-                  fill
-                  sizes="100vw"
-                  style={{ objectFit: "contain" }}
-                  alt={alt}
-                />
+                {/* Fixes a mobile error where edge of next image shows */}
+                <div className="m-2 w-full h-full relative flex justify-center">
+                  <Image
+                    src={imageURL}
+                    fill
+                    sizes="100vw"
+                    style={{ objectFit: "contain" }}
+                    alt={alt}
+                  />
+                </div>
               </div>
             ))}
           </MultiCarousel>

--- a/app/_components/IncomingData/InterestsData/Collage.tsx
+++ b/app/_components/IncomingData/InterestsData/Collage.tsx
@@ -24,7 +24,7 @@ export const Collage = () => {
         <motion.div
           initial="hidden"
           animate="show"
-          transition={{ staggerChildren: 0.1, staggerDirection: -1 }}
+          transition={{ staggerChildren: 0.1, staggerDirection: 1 }}
         >
           <InterestsGroup
             title="Exploring"

--- a/app/_components/IncomingData/InterestsData/Collage.tsx
+++ b/app/_components/IncomingData/InterestsData/Collage.tsx
@@ -38,12 +38,12 @@ export const Collage = () => {
           />
           <InterestsGroup
             title="Drones"
-            text={`He builds, repairs, races, and films with them`}
+            text="He builds, repairs, races, and films with them"
             imageData={DRONES_IMAGES}
           />
           <InterestsGroup
             title="Guitar"
-            text={`The Earthlings call it "Rock and Roll Baby"`}
+            text="The Earthlings call it 'Rock and Roll Baby'"
             imageData={GUITAR_IMAGES}
           />
         </motion.div>

--- a/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
+++ b/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
@@ -43,7 +43,7 @@ export const InterestsGroup = ({
           }
         )}
       >
-        {/* <Typist {...typistSettings}>{title}</Typist> */}
+        <Typist {...typistSettings}>{title}</Typist>
       </h2>
       <div
         className={classnames("flex ", {

--- a/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
+++ b/app/_components/IncomingData/InterestsData/InterestsGroup.tsx
@@ -43,21 +43,21 @@ export const InterestsGroup = ({
           }
         )}
       >
-        <Typist {...typistSettings}>{title}</Typist>
+        {/* <Typist {...typistSettings}>{title}</Typist> */}
       </h2>
       <div
         className={classnames("flex ", {
           "flex-row-reverse": isRTL,
         })}
       >
-        <p
+        <div
           // Text hidden on mobile
           className={classnames("w-4/12 pr-2 text-xs hidden sm:block", {
             "text-right pr-0 pl-2": isRTL,
           })}
         >
           <Typist {...typistSettings}>{text}</Typist>
-        </p>
+        </div>
 
         <div
           // Images full width on mobile

--- a/app/_components/IncomingData/InterestsData/Sighting.tsx
+++ b/app/_components/IncomingData/InterestsData/Sighting.tsx
@@ -34,6 +34,7 @@ export const Sighting = ({ imageURL, alt, isRTL }: Props) => {
       <Image
         src={imageURL}
         alt={alt}
+        sizes="20vw"
         fill
         style={{
           objectFit: "cover",


### PR DESCRIPTION
Adds some quality of life improvements to the carousel:

✅ Fixes an issue where the edge of the next image would show on mobile devices, by adding a small margin around the images
✅ Makes the images 95% of the screen instead of 80%
✅ Adds a dark background to the close button
✅ Ensures the close button is always on top/ clickable
✅ Removes the dots. These were making things too cluttered

Does some cleanup-along-the-way
✅ Fixes a `<div>` inside `<p>` error
✅ Fixes the stagger direction for `<InterestGroup/>` images
✅ Fixes some missing `sizes` with `<Image/>` components