### PR TITLE
Make incoming data taller

### DIFF
--- a/app/_components/IncomingData/index.tsx
+++ b/app/_components/IncomingData/index.tsx
@@ -90,7 +90,7 @@ export const IncomingData = ({ isForcedOpen }: Props) => {
   return (
     <div
       className={classnames(
-        "p-5 bg-blue-950/90 shadow-[0_0_15px_2px_#7Cbdbd_inset] border-2 border-sky-400 rounded-md text-sky-300 sm:w-[40vw] w-[90vw] h-[60vh] overflow-scroll",
+        "p-5 bg-blue-950/90 shadow-[0_0_15px_2px_#7Cbdbd_inset] border-2 border-sky-400 rounded-md text-sky-300 sm:w-[40vw] w-[90vw] sm:h-[60] h-[70vh] overflow-scroll top-[2vh]",
         spaceMono.className,
         styles.container,
         { [styles.containerClosed]: !isOpen }


### PR DESCRIPTION
Makes the `<IncomingData/>` component take up as much vertical space as possible without overlapping the console.