### PR TITLE
Disable image optimization

### DIFF
--- a/next.config.js
+++ b/next.config.js
@@ -1,6 +1,9 @@
 /** @type {import('next').NextConfig} */
 const nextConfig = {
   output: "export",
+  images: {
+    unoptimized: true,
+  },
   webpack: (config) => {
     config.module.rules.push({
       test: /\.(glb|gltf)$/,


### PR DESCRIPTION
Disables image optimization in Next config, to fix [https://stackoverflow.com/questions/73913732/nextjs-app-wont-export-due-to-image-optimization](this issue).