### PR TITLE
BlogEntry gradient fade and lower <br/>

### DIFF
--- a/app/_components/IncomingData/BlogData/BlogEntry.tsx
+++ b/app/_components/IncomingData/BlogData/BlogEntry.tsx
@@ -94,7 +94,7 @@ export const BlogEntry = ({
           {!isExpanded && (
             <div
               className={classnames(
-                "absolute h-full right-0 w-3",
+                "absolute h-full right-0 w-[10px]",
                 styles.tagContainerFadeBar
               )}
             />

--- a/app/_components/IncomingData/BlogData/BlogEntry.tsx
+++ b/app/_components/IncomingData/BlogData/BlogEntry.tsx
@@ -58,7 +58,7 @@ export const BlogEntry = ({
             </h3>
             <MdOpenInNew className="absolute top-[-2px] right-0 text-slate-400" />
           </button>
-          <hr className="flex-grow mx-3 border-slate-400" />
+          <hr className="flex-grow mx-3 border-slate-600" />
         </div>
 
         <div className="h-full mt-2">
@@ -123,13 +123,16 @@ export const BlogEntry = ({
         </div>
         <em
           className={classnames(
-            "sm:text-sm text-xs text-slate-400 ml-3 text-end",
+            "sm:text-sm text-xs text-slate-400  text-end flex justify-end items-center",
             {
               "w-full mt-3": isExpanded,
             }
           )}
         >
-          <FormattedDate value={createdAt} />
+          <hr className="flex-grow border-slate-600" />
+          <p className="ml-3">
+            <FormattedDate value={createdAt} />
+          </p>
         </em>
       </div>
     </div>

--- a/app/_components/IncomingData/BlogData/BlogEntry.tsx
+++ b/app/_components/IncomingData/BlogData/BlogEntry.tsx
@@ -86,25 +86,40 @@ export const BlogEntry = ({
         })}
       >
         <div
-          className={classnames("flex flex-grow", styles.tagContainer, {
-            "overflow-scroll": !isExpanded,
-            "flex-wrap": isExpanded,
-          })}
+          className={classnames(
+            "relative overflow-scroll w-full",
+            styles.tagContainer
+          )}
         >
-          {tags.map(({ value }, i) => (
-            <p
+          {!isExpanded && (
+            <div
               className={classnames(
-                "sm:text-base text-sm bg-sky-700 rounded py-1 px-2 text-[#00092A] mr-2",
-                styles.tag,
-                {
-                  "mt-3": isExpanded,
-                }
+                "absolute h-full right-0 w-3",
+                styles.tagContainerFadeBar
               )}
-              key={value + i}
-            >
-              {value}
-            </p>
-          ))}
+            />
+          )}
+          <div
+            className={classnames("flex flex-grow", styles.tagContainer, {
+              "overflow-scroll": !isExpanded,
+              "flex-wrap": isExpanded,
+            })}
+          >
+            {tags.map(({ value }, i) => (
+              <p
+                className={classnames(
+                  "sm:text-base text-sm bg-sky-700 rounded py-1 px-2 text-[#00092A] mr-2",
+                  styles.tag,
+                  {
+                    "mt-3": isExpanded,
+                  }
+                )}
+                key={value + i}
+              >
+                {value}
+              </p>
+            ))}
+          </div>
         </div>
         <em
           className={classnames(

--- a/app/_components/IncomingData/BlogData/blogEntry.module.css
+++ b/app/_components/IncomingData/BlogData/blogEntry.module.css
@@ -19,6 +19,10 @@
   display: none;
 }
 
+.tagContainerFadeBar {
+  background: linear-gradient(to right, rgba(255, 255, 255, 0), #00092A);
+}
+
 .tag {
   text-wrap: nowrap;
 }


### PR DESCRIPTION
Adds:

- A gradient fade to the end of the tags section, indicating to the user that horizontal scrolling is possible. This fade is only visible when there is overflow to the right of the tags container
- Another `<br/>` tag to the bottom of the `<BlogEntry/>` component. Only visible when expanded

Also darkens the `<br/>` tags so they are less pronounced.